### PR TITLE
Dev linux improvements

### DIFF
--- a/MelonLoader.Installer/GameLaunchers/EgsLauncher.cs
+++ b/MelonLoader.Installer/GameLaunchers/EgsLauncher.cs
@@ -47,7 +47,7 @@ public class EgsLauncher : GameLauncher
             if (name == null)
                 continue;
 
-            GameManager.TryAddGame(dir, name, this, null, out _);
+            GameManager.TryAddGame(dir, null, name, this, null, out _);
         }
     }
 }

--- a/MelonLoader.Installer/GameLaunchers/GogLauncher.cs
+++ b/MelonLoader.Installer/GameLaunchers/GogLauncher.cs
@@ -34,7 +34,7 @@ public class GogLauncher : GameLauncher
             if (name == null)
                 continue;
 
-            GameManager.TryAddGame(path, name, this, null, out _);
+            GameManager.TryAddGame(path, null, name, this, null, out _);
         }
     }
 }

--- a/MelonLoader.Installer/GameLaunchers/SteamLauncher.cs
+++ b/MelonLoader.Installer/GameLaunchers/SteamLauncher.cs
@@ -71,7 +71,7 @@ public class SteamLauncher : GameLauncher
                     continue;
 
                 var iconPath = Path.Combine(steamPath, "appcache", "librarycache", id + "_icon.jpg");
-                GameManager.TryAddGame(appDir, name, this, iconPath, out _);
+                GameManager.TryAddGame(appDir, id, name, this, iconPath, out _);
             }
         }
     }

--- a/MelonLoader.Installer/GameManager.cs
+++ b/MelonLoader.Installer/GameManager.cs
@@ -32,7 +32,7 @@ internal static class GameManager
     {
         foreach (var gamePath in Config.LoadGameList())
         {
-            TryAddGame(gamePath, null, null, null, out _);
+            TryAddGame(gamePath, null, null, null, null, out _);
         }
 
         // In case it was manually edited or if any games were removed
@@ -86,7 +86,7 @@ internal static class GameManager
         Games.Remove(game);
     }
 
-    public static GameModel? TryAddGame(string path, string? customName, GameLauncher? launcher, string? iconPath, [NotNullWhen(false)] out string? errorMessage)
+    public static GameModel? TryAddGame(string path, string? id, string? customName, GameLauncher? launcher, string? iconPath, [NotNullWhen(false)] out string? errorMessage)
     {
         if (File.Exists(path))
         {
@@ -169,7 +169,7 @@ internal static class GameManager
 
         var isProtected = Directory.Exists(Path.Combine(path, "EasyAntiCheat"));
 
-        var result = new GameModel(exe, customName ?? Path.GetFileNameWithoutExtension(exe), !is64, linux, launcher, icon, mlVersion, isProtected);
+        var result = new GameModel(exe, id, customName ?? Path.GetFileNameWithoutExtension(exe), !is64, linux, launcher, icon, mlVersion, isProtected);
         errorMessage = null;
 
         AddGameSorted(result);

--- a/MelonLoader.Installer/LinuxUtils.cs
+++ b/MelonLoader.Installer/LinuxUtils.cs
@@ -1,0 +1,112 @@
+#if LINUX
+using Avalonia;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using System.Runtime.InteropServices;
+
+namespace MelonLoader.Installer;
+
+internal static partial class LinuxUtils{
+    public static event InstallProgressEventHandler? Progress;
+    public static string DownloadUrlVCx64 = "https://aka.ms/vs/16/release/vc_redist.x64.exe";
+    public static string DownloadUrlVCx86 = "https://aka.ms/vs/16/release/vc_redist.x86.exe";
+    public static string TempDestination = "/tmp";
+    public static bool CheckIfBinaryExists(string name){
+        ProcessResult whichResult = RunCommand("which", name);
+        if (whichResult.ErrorLevel == 1){
+            return false;
+        }
+        return true;
+    }
+    public static bool CheckIfFlatpakExists(string name){
+        ProcessResult flatpakResult = RunCommand("flatpak", $"info {name}");
+        if (flatpakResult.ErrorLevel == 1){
+            return false;
+        }
+        return true;
+    }
+    public static bool CheckIfProtonTricksExists(){
+        if(CheckIfBinaryExists("protontricks")){
+            return true;
+        }
+        if(CheckIfFlatpakExists("com.github.Matoking.protontricks")){
+            return true;
+        }
+        return false;
+    }
+    public static void InstallProtonDependencies(string appId){
+        bool useFlatpak = false;
+        string command = "protontricks";
+        string commandLaunch = "protontricks-launch";
+        string launchArgPrefix = "--appid";
+        string argPrefix = "";
+        if(CheckIfFlatpakExists("com.github.Matoking.protontricks")){
+            useFlatpak = true;
+        }
+        if(CheckIfBinaryExists("protontricks")){
+            useFlatpak = false;
+        }
+        if(useFlatpak){
+            command = "flatpak";
+            commandLaunch = "flatpak";
+            argPrefix = "run com.github.Matoking.protontricks ";
+            launchArgPrefix = "run com.github.Matoking.protontricks --command=protontricks-launch --appid";
+        }
+        try{
+            string downloadPath = $"{TempDestination}/vc_redistx86.exe";
+            DownloadFile(DownloadUrlVCx86, downloadPath);
+            RunCommand(commandLaunch, $"{launchArgPrefix} {appId} {downloadPath}");
+            File.Delete(downloadPath);
+            downloadPath = $"{TempDestination}/vc_redistx64.exe";
+            DownloadFile(DownloadUrlVCx64, downloadPath);
+            RunCommand(commandLaunch, $"{launchArgPrefix} {appId} {downloadPath}");
+            File.Delete(downloadPath);
+        }
+        catch{
+            return;
+        }
+        RunCommand(command, $"{argPrefix}{appId} -q dotnetdesktop6");
+        
+    }
+    public static void OpenSteamGameProperties(string appId){
+        Process.Start($"steam://gameproperties/{appId}");
+    }
+    public static async void DownloadFile(string url, string destination){
+        var newStr = File.OpenWrite(destination);
+        var result = await InstallerUtils.DownloadFileAsync(url, newStr, (progress, newStatus) => Progress?.Invoke(progress, newStatus));
+        if (result != null)
+        {
+            throw new Exception($"Failed to download {url}: " + result);
+        }
+    }
+    public static ProcessResult RunCommand(string command, string arguments){
+        var escapedArgs = arguments.Replace("\"", "\\\"");
+        var process = new Process{
+            StartInfo = new ProcessStartInfo{
+                FileName = command,
+                Arguments = escapedArgs,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            }
+        };
+        process.Start();
+        process.WaitForExit();
+        string standardError = process.StandardError.ToString() ?? "";
+        string StandardOutput = process.StandardOutput.ToString() ?? "";
+        return new ProcessResult(process.ExitCode, standardError, StandardOutput);
+    }
+}
+
+internal class ProcessResult{
+    public int ErrorLevel;
+    public string ErrorOutput;
+    public string StandardOutput;
+    public ProcessResult(int ErrorLevel, string ErrorOutput, string StandardOutput){
+        this.ErrorLevel = ErrorLevel;
+        this.ErrorOutput = ErrorOutput;
+        this.StandardOutput = StandardOutput;
+    }
+}
+
+#endif

--- a/MelonLoader.Installer/LinuxUtils.cs
+++ b/MelonLoader.Installer/LinuxUtils.cs
@@ -80,9 +80,6 @@ internal static partial class LinuxUtils{
         SetProgress(0, "Install Proton dependency: dotnetdesktop6");
         await RunCommand(command, $"{argPrefix}{appId} -q dotnetdesktop6");
     }
-    public static async Task AddExecutePerm(string path){
-        await RunCommand("chmod", $"+x {path}");
-    }
     public static void OpenSteamGameProperties(string appId){
         Process.Start(new ProcessStartInfo(){
             FileName = $"steam://gameproperties/{appId}",

--- a/MelonLoader.Installer/MLManager.cs
+++ b/MelonLoader.Installer/MLManager.cs
@@ -407,7 +407,6 @@ internal static class MLManager
 
         if(IsProtonTricksInstalled && !linux){
             await LinuxUtils.InstallProtonDependencies(id, onProgress);
-            await LinuxUtils.AddExecutePerm($"{gameDir}/MelonLoader/Dependencies/Il2CppAssemblyGenerator/Cpp2IL/Cpp2IL");
         }
 
         #endif

--- a/MelonLoader.Installer/MLManager.cs
+++ b/MelonLoader.Installer/MLManager.cs
@@ -11,7 +11,7 @@ namespace MelonLoader.Installer;
 internal static class MLManager
 {
     private static bool inited;
-    public static bool IsProtonTricksInstalled;
+    public static bool IsProtonTricksInstalled = false;
     internal static readonly string[] proxyNames = 
     [
         "version.dll",
@@ -50,7 +50,9 @@ internal static class MLManager
             return true;
 
         inited = await RefreshVersions();
+        #if LINUX
         IsProtonTricksInstalled = await LinuxUtils.CheckIfProtonTricksExists();
+        #endif
         return inited;
     }
 
@@ -405,7 +407,7 @@ internal static class MLManager
 
         #if LINUX
 
-        if(IsProtonTricksInstalled && !linux){
+        if(IsProtonTricksInstalled && !linux && await LinuxUtils.CheckIfCanInstallDependencies(id)){
             await LinuxUtils.InstallProtonDependencies(id, onProgress);
         }
 

--- a/MelonLoader.Installer/ViewModels/GameModel.cs
+++ b/MelonLoader.Installer/ViewModels/GameModel.cs
@@ -4,9 +4,10 @@ using Semver;
 
 namespace MelonLoader.Installer.ViewModels;
 
-public class GameModel(string path, string name, bool is32Bit, bool isLinux, GameLauncher? launcher, Bitmap? icon, SemVersion? mlVersion, bool isProtected) : ViewModelBase
+public class GameModel(string path, string? id, string name, bool is32Bit, bool isLinux, GameLauncher? launcher, Bitmap? icon, SemVersion? mlVersion, bool isProtected) : ViewModelBase
 {
     public string Path => path;
+    public string? Id => id;
     public string Name => name;
     public bool Is32Bit => is32Bit;
     public bool IsLinux => isLinux;

--- a/MelonLoader.Installer/Views/DetailsView.axaml
+++ b/MelonLoader.Installer/Views/DetailsView.axaml
@@ -74,7 +74,7 @@
                     <TextBlock TextWrapping="Wrap">In order to start MelonLoader under Wine, you'll need to export the following variable:</TextBlock>
                     <TextBox Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True">WINEDLLOVERRIDES="version=n,b"</TextBox>
                     <TextBlock TextWrapping="Wrap">On Steam, you can set the launch options to:</TextBlock>
-                    <TextBox Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True">WINEDLLOVERRIDES="version=n,b" %command%"</TextBox>
+                    <TextBox Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True">WINEDLLOVERRIDES="version=n,b" %command%</TextBox>
                 </StackPanel>
                 <StackPanel Orientation="Vertical" IsVisible="{Binding Game.IsLinux}" Grid.Row="1">
                     <TextBlock TextWrapping="Wrap">In order to start MelonLoader, you'll need to export the following variables:</TextBlock>

--- a/MelonLoader.Installer/Views/DetailsView.axaml
+++ b/MelonLoader.Installer/Views/DetailsView.axaml
@@ -58,26 +58,36 @@
                     VerticalAlignment="Center" Opacity="0.7" FontSize="14" />
             </Grid>
         </Grid>
-        
+
         <TextBlock Name="ShowLinuxInstructions" IsEnabled="{Binding !Installing}" Grid.Row="14" Tapped="ShowLinuxInstructionsHandler" HorizontalAlignment="Center" Foreground="Gray" TextDecorations="Underline" FontSize="13" Cursor="Hand" IsVisible="False">
             How do I start MelonLoader?
         </TextBlock>
+        <StackPanel Name="ShowProtonTricksWarning" Orientation="Vertical" IsVisible="false" Grid.Row="15" >
+            <TextBlock HorizontalAlignment="Center" Foreground="Gray" FontSize="13">
+                Proton tricks is missing. Proton Dependencies will be skipped.
+            </TextBlock>
+        </StackPanel>
     </Grid>
         <Grid Grid.Row="1" Margin="30" RowDefinitions="auto, *" IsVisible="{Binding LinuxInstructions}">
             <TextBlock Grid.Row="0" FontSize="25" Margin="0 0 0 20">Linux Launch Instructions</TextBlock>
-                    <StackPanel Orientation="Vertical" IsVisible="{Binding !Game.IsLinux}" Grid.Row="1">
-                        <TextBlock TextWrapping="Wrap">In order to start MelonLoader under Wine, you'll need to export the following variable:</TextBlock>
-                        <TextBox Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True">WINEDLLOVERRIDES="version=n,b"</TextBox>
-                        <TextBlock TextWrapping="Wrap">On Steam, you can set the launch options to:</TextBlock>
-                        <TextBox Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True">WINEDLLOVERRIDES="version=n,b" %command%"</TextBox>
-                    </StackPanel>
-                    <StackPanel Orientation="Vertical" IsVisible="{Binding Game.IsLinux}" Grid.Row="1">
-                        <TextBlock TextWrapping="Wrap">In order to start MelonLoader, you'll need to export the following variables:</TextBlock>
-                        <TextBox Name="LdLibPathVar" Margin="0 4 0 0" BorderBrush="Transparent" IsReadOnly="True"/>
-                        <TextBox Name="LdPreloadVar" Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True">LD_PRELOAD="libversion.so"</TextBox>
-                        <TextBlock TextWrapping="Wrap">On Steam, you can set the launch options to:</TextBlock>
-                        <TextBox Name="SteamLaunchOptions" Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True"/>
-                    </StackPanel>
+                <StackPanel Orientation="Vertical" IsVisible="{Binding !Game.IsLinux}" Grid.Row="1">
+                    <TextBlock TextWrapping="Wrap">In order to start MelonLoader under Wine, you'll need to export the following variable:</TextBlock>
+                    <TextBox Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True">WINEDLLOVERRIDES="version=n,b"</TextBox>
+                    <TextBlock TextWrapping="Wrap">On Steam, you can set the launch options to:</TextBlock>
+                    <TextBox Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True">WINEDLLOVERRIDES="version=n,b" %command%"</TextBox>
+                </StackPanel>
+                <StackPanel Orientation="Vertical" IsVisible="{Binding Game.IsLinux}" Grid.Row="1">
+                    <TextBlock TextWrapping="Wrap">In order to start MelonLoader, you'll need to export the following variables:</TextBlock>
+                    <TextBox Name="LdLibPathVar" Margin="0 4 0 0" BorderBrush="Transparent" IsReadOnly="True"/>
+                    <TextBox Name="LdPreloadVar" Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True">LD_PRELOAD="libversion.so"</TextBox>
+                    <TextBlock TextWrapping="Wrap">On Steam, you can set the launch options to:</TextBlock>
+                    <TextBox Name="SteamLaunchOptions" Margin="0 4 0 10" BorderBrush="Transparent" IsReadOnly="True"/>
+                </StackPanel>
+            <Button Grid.Row="2" Click="GamePropsHandler" Name="GamePropsButton"
+                HorizontalAlignment="Stretch" Background="#383" Height="40"
+                HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                FontSize="18">Open Steam Game Properties
+            </Button>
         </Grid>
     </Grid>
 </UserControl>

--- a/MelonLoader.Installer/Views/MainView.axaml.cs
+++ b/MelonLoader.Installer/Views/MainView.axaml.cs
@@ -103,7 +103,7 @@ public partial class MainView : UserControl
             return;
 
         var path = files[0].Path.LocalPath;
-        GameManager.TryAddGame(path, null, null, null, out var error);
+        GameManager.TryAddGame(path, null, null, null, null, out var error);
         if (error != null)
         {
             DialogBox.ShowError(error);


### PR DESCRIPTION
* Add automatic installing of proton dependencies (vc_redist and dotnetdesktop)
* Make how to launch show by default for linux after installation to provide commands more readily to the user
* Add a button to open the steam game properties dialogue directly
* Add various linux utilities to make it easy to install dependencies
* Supports dependency installation via native and flatpak protontricks with native being preferred.

Let me know if any additional changes need to be made. This should hopefully reduce the amount of effort and confusion people have with getting MelonLoader running under linux.