### PR TITLE
Enable caching of downloading MelonLoader archive

### DIFF
--- a/MelonLoader.Installer/InstallerUtils.cs
+++ b/MelonLoader.Installer/InstallerUtils.cs
@@ -1,10 +1,12 @@
 ﻿using System.IO.Compression;
+using System.Security.Cryptography;
 
 namespace MelonLoader.Installer;
 
 public static class InstallerUtils
 {
     public static HttpClient Http { get; }
+    private static readonly SHA512 Hasher = SHA512.Create();
 
     static InstallerUtils()
     {
@@ -12,8 +14,27 @@ public static class InstallerUtils
         Http.DefaultRequestHeaders.Add("User-Agent", $"MelonLoader Installer v{Program.VersionName}");
     }
 
-    public static async Task<string?> DownloadFileAsync(string url, Stream destination, InstallProgressEventHandler? onProgress)
+    private static async Task<string?> FetchFile(string url, Stream destination, bool useCache, InstallProgressEventHandler? onProgress)
     {
+        // Cache preparation
+        var parentDirectory = Path.GetFileName(Path.GetDirectoryName(url)) ?? "";
+        var fileCache = Path.Combine(Config.CacheDir, "Cache", parentDirectory, Path.GetFileName(url));
+
+        // Cache hits
+        if (useCache && File.Exists(fileCache))
+        {
+            try
+            {
+                await using var fsOut = File.OpenRead(fileCache);
+                await fsOut.CopyToAsync(destination);
+                return null;
+            }
+            catch
+            {
+                return $"Failed to read the cache file {fileCache}";
+            }
+        }
+        
         HttpResponseMessage response;
         try
         {
@@ -33,33 +54,75 @@ public static class InstallerUtils
             return response.ReasonPhrase;
         }
 
-        using var content = await response.Content.ReadAsStreamAsync();
+        await using var content = await response.Content.ReadAsStreamAsync();
 
         var length = response.Content.Headers.ContentLength ?? 0;
 
         if (length > 0)
         {
             destination.SetLength(length);
+            var position = 0;
+            var buffer = new byte[1024 * 16];
+            while (position < destination.Length - 1)
+            {
+                var read = await content.ReadAsync(buffer, 0, buffer.Length);
+                await destination.WriteAsync(buffer, 0, read);
+
+                position += read;
+
+                onProgress?.Invoke(position / (double)(destination.Length - 1), null);
+            }
         }
         else
         {
             await content.CopyToAsync(destination);
-            return null;
         }
-
-        var position = 0;
-        var buffer = new byte[1024 * 16];
-        while (position < destination.Length - 1)
+        
+        // Save cache
+        if (useCache)
         {
-            var read = await content.ReadAsync(buffer, 0, buffer.Length);
-            await destination.WriteAsync(buffer, 0, read);
-
-            position += read;
-
-            onProgress?.Invoke(position / (double)(destination.Length - 1), null);
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(Config.CacheDir, "Cache", parentDirectory));
+                await using var fsIn = File.OpenWrite(fileCache);
+                destination.Seek(0, SeekOrigin.Begin);
+                await destination.CopyToAsync(fsIn);
+            }
+            catch
+            {
+                // Failed to save cache
+            }
         }
-
         return null;
+    }
+
+    public static async Task<string?> DownloadFileAsync(string url, Stream destination, bool useCache, InstallProgressEventHandler? onProgress)
+    {
+        // Get archive
+        var result = await FetchFile(url, destination, useCache, onProgress);
+        if (result != null)
+            return $"Failed to fetch file from {url}: {result}";
+
+        destination.Seek(0, SeekOrigin.Begin);
+        
+        // Get checksum
+        var checksumUrl = url.Replace(".zip", ".sha512");
+        using var checksumStr = new MemoryStream();
+        result = await FetchFile(checksumUrl, checksumStr, useCache, onProgress);
+
+        // Checksum fetch failed, skip verification
+        if (result != null) return null;
+        
+        var checksumDownload = System.Text.Encoding.UTF8.GetString(checksumStr.ToArray());
+        var checksumCompute = Convert.ToHexString(await Hasher.ComputeHashAsync(destination));
+        
+        // Verification successful
+        if (checksumCompute == checksumDownload) return null;
+        // Verification failed, remove corrupted files
+        var parentDirectory = Path.GetFileName(Path.GetDirectoryName(url)) ?? "";
+        File.Delete(Path.Combine(Config.CacheDir, "Cache", parentDirectory, Path.GetFileName(url)));
+        File.Delete(Path.Combine(Config.CacheDir, "Cache", parentDirectory, Path.GetFileName(checksumUrl)));
+        return "Fetched corrupted file (checksum mismatch)";
     }
 
     public static string? Extract(Stream archiveStream, string destination, InstallProgressEventHandler? onProgress)

--- a/MelonLoader.Installer/MLManager.cs
+++ b/MelonLoader.Installer/MLManager.cs
@@ -310,7 +310,7 @@ internal static class MLManager
             return;
         }
 
-        var mlVer = MLVersion.GetMelonLoaderVersion(Config.LocalZipCache, out var x86, out var linux);
+        var mlVer = MLVersion.GetMelonLoaderVersion(Config.LocalZipCache, out var arch);
         if (mlVer == null)
         {
             onFinished?.Invoke("The selected zip archive does not contain a valid MelonLoader build.");
@@ -320,9 +320,9 @@ internal static class MLManager
         var version = new MLVersion()
         {
             Version = mlVer,
-            DownloadUrlWin = !linux ? (!x86 ? Config.LocalZipCache : null) : null,
-            DownloadUrlWinX86 = !linux ? (x86 ? Config.LocalZipCache : null) : null,
-            DownloadUrlLinux = linux ? Config.LocalZipCache : null,
+            DownloadUrlWin = arch == Architecture.WindowsX64 ? Config.LocalZipCache : null,
+            DownloadUrlWinX86 = arch == Architecture.WindowsX86 ? Config.LocalZipCache : null,
+            DownloadUrlLinux = arch == Architecture.LinuxX64 ? Config.LocalZipCache : null,
             IsLocalPath = true
         };
 
@@ -332,12 +332,19 @@ internal static class MLManager
         onFinished?.Invoke(null);
     }
 
-    public static async Task InstallAsync(string gameDir, bool removeUserFiles, MLVersion version, bool linux, bool x86, InstallProgressEventHandler? onProgress, InstallFinishedEventHandler? onFinished)
+    public static async Task InstallAsync(string gameDir, bool removeUserFiles, MLVersion version, Architecture arch, InstallProgressEventHandler? onProgress, InstallFinishedEventHandler? onFinished)
     {
-        var downloadUrl = linux ? (!x86 ? version.DownloadUrlLinux : null) : (x86 ? version.DownloadUrlWinX86 : version.DownloadUrlWin);
+        var downloadUrl = arch switch
+        {
+            Architecture.LinuxX64 => version.DownloadUrlLinux,
+            Architecture.WindowsX64 => version.DownloadUrlWin,
+            Architecture.WindowsX86 => version.DownloadUrlWinX86,
+            _ => null
+        };
+
         if (downloadUrl == null)
         {
-            onFinished?.Invoke($"The selected version does not support the selected architecture: {(linux ? "linux" : "win")}-{(x86 ? "x86" : "x64")}");
+            onFinished?.Invoke($"The selected version does not support the selected architecture: {arch.GetDescription()}");
             return;
         }
 

--- a/MelonLoader.Installer/MLManager.cs
+++ b/MelonLoader.Installer/MLManager.cs
@@ -388,7 +388,7 @@ internal static class MLManager
             SetProgress(0, "Downloading MelonLoader " + version);
 
             using var bufferStr = new MemoryStream();
-            var result = await InstallerUtils.DownloadFileAsync(downloadUrl, bufferStr, SetProgress);
+            var result = await InstallerUtils.DownloadFileAsync(downloadUrl, bufferStr, true, SetProgress);
             if (result != null)
             {
                 onFinished?.Invoke("Failed to download MelonLoader: " + result);

--- a/MelonLoader.Installer/Updater.cs
+++ b/MelonLoader.Installer/Updater.cs
@@ -86,7 +86,7 @@ public static partial class Updater
 
         await using (var newStr = File.OpenWrite(newPath))
         {
-            var result = await InstallerUtils.DownloadFileAsync(downloadUrl, newStr, (progress, newStatus) => Progress?.Invoke(progress, newStatus));
+            var result = await InstallerUtils.DownloadFileAsync(downloadUrl, newStr, false, (progress, newStatus) => Progress?.Invoke(progress, newStatus));
             if (result != null)
             {
                 throw new Exception("Failed to download the latest installer version: " + result);

--- a/MelonLoader.Installer/ViewModels/GameModel.cs
+++ b/MelonLoader.Installer/ViewModels/GameModel.cs
@@ -4,12 +4,12 @@ using Semver;
 
 namespace MelonLoader.Installer.ViewModels;
 
-public class GameModel(string path, string name, bool is32Bit, bool isLinux, GameLauncher? launcher, Bitmap? icon, SemVersion? mlVersion, bool isProtected) : ViewModelBase
+public class GameModel(string path, string name, Architecture architecture, GameLauncher? launcher, Bitmap? icon, SemVersion? mlVersion, bool isProtected) : ViewModelBase
 {
     public string Path => path;
     public string Name => name;
-    public bool Is32Bit => is32Bit;
-    public bool IsLinux => isLinux;
+    public Architecture Arch => architecture;
+    public bool IsLinux => architecture == Architecture.LinuxX64;
     public GameLauncher? Launcher => launcher;
     public Bitmap? Icon => icon;
     public string? MLVersionText => mlVersion != null ? 'v' + mlVersion.ToString() : null;
@@ -47,8 +47,8 @@ public class GameModel(string path, string name, bool is32Bit, bool isLinux, Gam
             return false;
         }
 
-        var newMlVersion = Installer.MLVersion.GetMelonLoaderVersion(Dir, out var ml86, out var mlLinux);
-        if (newMlVersion != null && (ml86 != Is32Bit || mlLinux != IsLinux))
+        var newMlVersion = Installer.MLVersion.GetMelonLoaderVersion(Dir, out var arch);
+        if (newMlVersion != null && arch != Arch)
             newMlVersion = null;
         
         if (newMlVersion == MLVersion) 

--- a/MelonLoader.Installer/Views/GameControl.axaml.cs
+++ b/MelonLoader.Installer/Views/GameControl.axaml.cs
@@ -29,7 +29,7 @@ public partial class GameControl : UserControl
 
         var showWine =
 #if LINUX
-            !Model.IsLinux;
+            Model.Arch != Architecture.LinuxX64;
 #else
             false;
 #endif


### PR DESCRIPTION
Currently MelonLoader.Installer fetches installation archive every time on installation event. This can be slow and user can restricted by download throttling from GitHub. This feature enables caching of successfully downloaded archives for possible re-use with optional SHA512 checksum verification.
Cache files are stored in `CacheDir / Cache`  directory.