### PR TITLE
Hotfixes

### DIFF
--- a/.github/workflows/build-final.yml
+++ b/.github/workflows/build-final.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
         
       - name: Restore Dependencies
         run: dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: Build Installer
 
-run-name: 4.1.1-ci.${{ github.run_number }} | ${{ github.event_name != 'workflow_dispatch' && (github.event.head_commit.message || format('`[PR]` {0}', github.event.pull_request.title)) || 'Manual Build' }}
+run-name: 4.1.2-ci.${{ github.run_number }} | ${{ github.event_name != 'workflow_dispatch' && (github.event.head_commit.message || format('`[PR]` {0}', github.event.pull_request.title)) || 'Manual Build' }}
 
 env:
-  DEVVERSION: "4.1.1"
+  DEVVERSION: "4.1.2"
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Restore Dependencies
         run: dotnet restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
     <PropertyGroup>
-        <Version>4.1.1</Version>
+        <Version>4.1.2</Version>
 		
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 
         <!-- Sets the default identifiers. They can be overridden -->
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>

--- a/MelonLoader.Installer/GameLaunchers/SteamLauncher.cs
+++ b/MelonLoader.Installer/GameLaunchers/SteamLauncher.cs
@@ -70,7 +70,16 @@ public class SteamLauncher : GameLauncher
                 if (!Directory.Exists(appDir))
                     continue;
 
-                var iconPath = Path.Combine(steamPath, "appcache", "librarycache", id + "_icon.jpg");
+                var iconPath = Path.Combine(steamPath, "appcache", "librarycache", id);
+                iconPath = Directory.Exists(iconPath)
+                    ? Directory.EnumerateFiles(iconPath, "*.jpg").FirstOrDefault(x =>
+                    {
+                        var fileName = Path.GetFileName(x);
+                        return !fileName.StartsWith("library") && !fileName.StartsWith("header") &&
+                               !fileName.StartsWith("logo");
+                    })
+                    : null;
+                
                 GameManager.TryAddGame(appDir, name, this, iconPath, out _);
             }
         }

--- a/MelonLoader.Installer/GameManager.cs
+++ b/MelonLoader.Installer/GameManager.cs
@@ -103,11 +103,11 @@ internal static class GameManager
         var arch = Architecture.Unknown;
 
         var rawDataDirs = Directory.GetDirectories(path, "*_Data");
-        var dataDirs = rawDataDirs.Where(x => File.Exists(x[..^5] + ".exe")).ToArray();
-        if (dataDirs.Length == 0)
+        var dataDirs = rawDataDirs.Where(x => File.Exists(x[..^5] + ".exe"));
+        if (!dataDirs.Any())
         {
-            dataDirs = rawDataDirs.Where(x => File.Exists(x[..^5] + ".x86_64")).ToArray();
-            if (dataDirs.Length != 0)
+            dataDirs = rawDataDirs.Where(x => File.Exists(x[..^5] + ".x86_64"));
+            if (dataDirs.Any())
             {
                 arch = Architecture.LinuxX64;
             }
@@ -118,13 +118,13 @@ internal static class GameManager
             }
         }
         
-        if (dataDirs.Length > 1)
+        if (dataDirs.Count() > 1)
         {
             errorMessage = "The selected directory contains multiple Unity games?";
             return null;
         }
 
-        var exe = dataDirs[0][..^5] + (arch == Architecture.LinuxX64 ? ".x86_64" : ".exe");
+        var exe = dataDirs.First()[..^5] + (arch == Architecture.LinuxX64 ? ".x86_64" : ".exe");
 
         if (Games.Any(x => x.Path.Equals(exe, StringComparison.OrdinalIgnoreCase)))
         {

--- a/MelonLoader.Installer/MLVersion.cs
+++ b/MelonLoader.Installer/MLVersion.cs
@@ -44,7 +44,7 @@ public class MLVersion
             var fileVersionRaw = FileVersionInfo.GetVersionInfo(mlAssemblyPath).FileVersion!;
             var fileVersion = System.Version.Parse(fileVersionRaw);
             version = SemVersion.ParsedFrom(fileVersion.Major, fileVersion.Minor, fileVersion.Build,
-                fileVersion.Revision == 0 ? string.Empty : $"ci.{fileVersion.Revision}");
+                fileVersion.Revision <= 0 ? string.Empty : $"ci.{fileVersion.Revision}");
         }
         catch
         {

--- a/MelonLoader.Installer/Program.cs
+++ b/MelonLoader.Installer/Program.cs
@@ -85,15 +85,23 @@ internal static class Program
 
     public static void RestartWithElevatedPrivileges()
     {
-#if WINDOWS
-        Process.Start(new ProcessStartInfo(Environment.ProcessPath!, ["-wait", Environment.ProcessId.ToString()])
+        try
         {
-            UseShellExecute = true,
-            Verb = "runas"
-        });
+#if WINDOWS
+            Process.Start(new ProcessStartInfo(Environment.ProcessPath!, ["-wait", Environment.ProcessId.ToString()])
+            {
+                UseShellExecute = true,
+                Verb = "runas"
+            });
 #else
-        Process.Start("pkexec", [Environment.ProcessPath!, "-wait", Environment.ProcessId.ToString()]);
+            Process.Start("pkexec", [Environment.ProcessPath!, "-wait", Environment.ProcessId.ToString()]);
 #endif
+        }
+        catch
+        {
+            // This may happen if the user refuses to start the new process as admin
+            return;
+        }
 
         Environment.Exit(0);
     }

--- a/MelonLoader.Installer/Program.cs
+++ b/MelonLoader.Installer/Program.cs
@@ -40,6 +40,14 @@ internal static class Program
             {
                 Updater.WaitAndRemoveApp(args[1], pid);
             }
+            else if (args[0] == "-wait")
+            {
+                try
+                {
+                    Process.GetProcessById(pid).WaitForExit();
+                }
+                catch { }
+            }
         }
 
 #if WINDOWS
@@ -73,6 +81,21 @@ internal static class Program
             File.WriteAllText(logPath, ex.ToString());
         }
         catch { }
+    }
+
+    public static void RestartWithElevatedPrivileges()
+    {
+#if WINDOWS
+        Process.Start(new ProcessStartInfo("pkexec", [Environment.ProcessPath!, "-wait", Process.GetCurrentProcess().Id.ToString()])
+        {
+            UseShellExecute = true,
+            Verb = "runas"
+        });
+#else
+        Process.Start("pkexec", [Environment.ProcessPath!, "-wait", Process.GetCurrentProcess().Id.ToString()]);
+#endif
+        
+        Environment.Exit(0);
     }
 
     private static bool CheckProcessLock()

--- a/MelonLoader.Installer/Program.cs
+++ b/MelonLoader.Installer/Program.cs
@@ -86,15 +86,15 @@ internal static class Program
     public static void RestartWithElevatedPrivileges()
     {
 #if WINDOWS
-        Process.Start(new ProcessStartInfo("pkexec", [Environment.ProcessPath!, "-wait", Process.GetCurrentProcess().Id.ToString()])
+        Process.Start(new ProcessStartInfo(Environment.ProcessPath!, ["-wait", Environment.ProcessId.ToString()])
         {
             UseShellExecute = true,
             Verb = "runas"
         });
 #else
-        Process.Start("pkexec", [Environment.ProcessPath!, "-wait", Process.GetCurrentProcess().Id.ToString()]);
+        Process.Start("pkexec", [Environment.ProcessPath!, "-wait", Environment.ProcessId.ToString()]);
 #endif
-        
+
         Environment.Exit(0);
     }
 

--- a/MelonLoader.Installer/Views/DetailsView.axaml.cs
+++ b/MelonLoader.Installer/Views/DetailsView.axaml.cs
@@ -142,6 +142,9 @@ public partial class DetailsView : UserControl
             return;
         }
 
+        if (AskForElevation())
+            return;
+
         Model.Installing = true;
         ShowLinuxInstructions.IsVisible = false;
 
@@ -149,6 +152,35 @@ public partial class DetailsView : UserControl
             (MLVersion)VersionCombobox.SelectedItem!, Model.Game.Arch,
             (progress, newStatus) => Dispatcher.UIThread.Post(() => OnInstallProgress(progress, newStatus)),
             (errorMessage) => Dispatcher.UIThread.Post(() => OnOperationFinished(errorMessage)));
+    }
+    
+    public bool AskForElevation()
+    {
+        var tempPath = Path.Combine(Model!.Game.Dir, "ml.tmp");
+        try
+        {
+            using var file = File.Create(tempPath);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            DialogBox.ShowConfirmation(
+                "The installation of MelonLoader on this game may require elevated privileges.\nWould you like to restart with elevated privileges?",
+                Program.RestartWithElevatedPrivileges);
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+
+        try
+        {
+            File.Delete(tempPath);
+        }
+        catch { }
+        
+        return false;
     }
 
     private void OnInstallProgress(double progress, string? newStatus)
@@ -218,7 +250,7 @@ public partial class DetailsView : UserControl
             return;
         }
 
-        if (!Model.Game.MLInstalled)
+        if (!Model.Game.MLInstalled || AskForElevation())
             return;
 
         var error = MLManager.Uninstall(Model.Game.Dir, !KeepFilesCheck.IsChecked!.Value);

--- a/MelonLoader.Installer/Views/DetailsView.axaml.cs
+++ b/MelonLoader.Installer/Views/DetailsView.axaml.cs
@@ -161,7 +161,7 @@ public partial class DetailsView : UserControl
         {
             using var file = File.Create(tempPath);
         }
-        catch (UnauthorizedAccessException ex)
+        catch (UnauthorizedAccessException)
         {
             DialogBox.ShowConfirmation(
                 "The installation of MelonLoader on this game may require elevated privileges.\nWould you like to restart with elevated privileges?",

--- a/MelonLoader.Installer/Views/DialogBox.axaml
+++ b/MelonLoader.Installer/Views/DialogBox.axaml
@@ -25,8 +25,8 @@
             <Button Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center" Click="ConfirmHandler">OK</Button>
         </Grid>
         <Grid IsVisible="{Binding IsConfirmation}" Grid.Column="0" Grid.Row="2" VerticalAlignment="Bottom" HorizontalAlignment="Center" ColumnDefinitions="60, 60" RowDefinitions="60">
-            <Button Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center" Click="CancelHandler" Content="{Binding CancelText}"/>
-            <Button Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center" Click="ConfirmHandler" Content="{Binding ConfirmText}"/>
+            <Button Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center" Click="CancelHandler" Content="{Binding CancelText}"/>
+            <Button Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center" Click="ConfirmHandler" Background="#383" Content="{Binding ConfirmText}"/>
         </Grid>
     </Grid>
 </Window>

--- a/MelonLoader.Installer/Views/DialogBox.axaml.cs
+++ b/MelonLoader.Installer/Views/DialogBox.axaml.cs
@@ -55,9 +55,9 @@ public partial class DialogBox : Window
         string message,
         Action? onConfirm = null,
         Action? onCancel = null,
-        string confirmText = "YES",
-        string cancelText = "NO")
-        => ShowConfirmation("CONFIRMATION",
+        string confirmText = "Yes",
+        string cancelText = "No")
+        => ShowConfirmation("Confirmation",
             message,
             onConfirm,
             onCancel,
@@ -69,8 +69,8 @@ public partial class DialogBox : Window
         string message,
         Action? onConfirm = null,
         Action? onCancel = null,
-        string confirmText = "YES",
-        string cancelText = "NO")
+        string confirmText = "Yes",
+        string cancelText = "No")
     {
         new DialogBox
         {


### PR DESCRIPTION
- Bumped the version number to 4.1.2
- Bumped the .NET version to 9.0 (this was previously reverted due to random crashing issues, though the relation has been disproven)
- Fixed the Wine setup instructions
- Fixed negative CI build numbers
- Fixed missing Steam game icons
- Added proper handling for games located in directories that require elevated privileges. The installer will now ask the user whether they'd like to restart the installer under elevated privileges before installation starts.