### PR TITLE
make macOS executable… executable

### DIFF
--- a/MelonLoader.Installer/MelonLoader.Installer.csproj
+++ b/MelonLoader.Installer/MelonLoader.Installer.csproj
@@ -74,4 +74,8 @@
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>
+
+    <Target Name="SetExecutablePermissions" AfterTargets="Publish" Condition="'$(RuntimeIdentifier.StartsWith(`osx-`))' == 'true'">
+      <Exec Command="chmod +x &quot;$(PublishDir)$(AssemblyName)&quot;" />
+    </Target>
 </Project>


### PR DESCRIPTION
Before this, the executable file within the .app bundle for the macOS app didn't have the executable flag, so would respond with an error:

```
The application cannot be opened for an unexpected reason, error=Error Domain=RBSRequestErrorDomain Code=5 "Launch failed." UserInfo={NSLocalizedFailureReason=Launch failed., NSUnderlyingError=0x6000022b0060 {Error Domain=NSPOSIXErrorDomain Code=111 "Unknown error: 111" UserInfo={NSLocalizedDescription=Launchd job spawn failed}}}
```

> [!WARNING]
> Please note, I'm unfamiliar with .Net development. This works on my machine, but please check it carefully.

Fixes #74 