### PR TITLE
Fix: Game architecture detection on macOS and Linux

### DIFF
--- a/MelonLoader.Installer/GameManager.cs
+++ b/MelonLoader.Installer/GameManager.cs
@@ -205,6 +205,13 @@ internal static class GameManager
             _ => Architecture.Unknown
         };
 
+        if (result == Architecture.MacOSX64)
+        {
+            var unityPlayerPath = Path.Combine(exe, "Contents/Frameworks/UnityPlayer.dylib");
+            if (File.Exists(unityPlayerPath))
+                result = MLVersion.ReadFromMachO(unityPlayerPath);
+        }
+
         if (result == Architecture.Unknown)
         {
             var unityPlayerPath = Path.Combine(Path.GetDirectoryName(exe)!, "UnityPlayer.dll");

--- a/MelonLoader.Installer/GameManager.cs
+++ b/MelonLoader.Installer/GameManager.cs
@@ -107,31 +107,26 @@ internal static class GameManager
         path = Path.GetFullPath(path);
 
         // Validate Directory contains Applications
-        exeExt = ".app";
-        string? referenceExt = exeExt;
-        int skipCount = 4;
-        var rawDataDirs = Directory.GetDirectories(path, $"*{exeExt}");
-        var dataDirs = rawDataDirs.Where(x => Directory.Exists(x[..^skipCount] + referenceExt));
-        if (!dataDirs.Any())
+        var skipCount = 5;
+        IEnumerable<string> dataDirs = [];
+        ReadOnlySpan<string> extensions = [".app", ".exe", ".x86_64", ""];
+        foreach (var referenceExt in extensions)
         {
-            exeExt = ".exe";
-            referenceExt = exeExt;
-            skipCount = 5;
-            rawDataDirs = Directory.GetDirectories(path, "*_Data");
-            dataDirs = rawDataDirs.Where(x => File.Exists(x[..^skipCount] + referenceExt));
-            if (!dataDirs.Any())
-            {
-                exeExt = ".x86_64";
-                referenceExt = exeExt;
-                dataDirs = rawDataDirs.Where(x => File.Exists(x[..^skipCount] + referenceExt));
-                if (!dataDirs.Any())
-                {
-                    errorMessage = "The selected directory does not contain a Unity game.";
-                    return false;
-                }
-            }
+            exeExt = referenceExt;
+            skipCount = referenceExt == ".app" ? 4 : 5;
+            var searchPattern = referenceExt == ".app" ? $"*{exeExt}" : "*_Data";
+            var rawDataDirs = Directory.GetDirectories(path, searchPattern);
+            Func<string?, bool> exists = referenceExt == ".app" ? Directory.Exists : File.Exists;
+            dataDirs = rawDataDirs.Where(x => exists(x[..^skipCount] + referenceExt));
+            if (dataDirs.Any()) break;
         }
 
+        if (!dataDirs.Any())
+        {
+            errorMessage = "The selected directory does not contain a Unity game.";
+            return false;
+        }
+        
         // Validate Directory only contains 1 Application
         if (dataDirs.Count() > 1)
         {

--- a/MelonLoader.Installer/GameManager.cs
+++ b/MelonLoader.Installer/GameManager.cs
@@ -208,8 +208,7 @@ internal static class GameManager
         if (result == Architecture.MacOSX64)
         {
             var unityPlayerPath = Path.Combine(exe, "Contents/Frameworks/UnityPlayer.dylib");
-            if (File.Exists(unityPlayerPath))
-                result = MLVersion.ReadFromMachO(unityPlayerPath);
+            result = File.Exists(unityPlayerPath) ? MLVersion.ReadFromMachO(unityPlayerPath) : Architecture.Unknown;
         }
 
         if (result == Architecture.Unknown)

--- a/MelonLoader.Installer/GameManager.cs
+++ b/MelonLoader.Installer/GameManager.cs
@@ -197,30 +197,23 @@ internal static class GameManager
 
     private static Architecture GetGameArchitecture(string exe, string exeExt)
     {
-        Architecture result = Architecture.Unknown;
-        switch (exeExt)
+        var result = exeExt switch
         {
-            case ".app":
-                result = Architecture.MacOSX64;
-                break;
-
-            case ".exe":
-                result = MLVersion.ReadFromPE(exe);
-                break;
-
-            case ".x86_64":
-                result = Architecture.LinuxX64;
-                break;
-
-            default:
-                break;
-        }
+            ".app" => Architecture.MacOSX64,
+            ".exe" => MLVersion.ReadFromPE(exe),
+            ".x86_64" => Architecture.LinuxX64,
+            _ => Architecture.Unknown
+        };
 
         if (result == Architecture.Unknown)
         {
             var unityPlayerPath = Path.Combine(Path.GetDirectoryName(exe)!, "UnityPlayer.dll");
             if (File.Exists(unityPlayerPath))
                 result = MLVersion.ReadFromPE(unityPlayerPath);
+
+            var unityPlayerLinuxPath = Path.Combine(Path.GetDirectoryName(exe)!, "UnityPlayer.so");
+            if (File.Exists(unityPlayerLinuxPath))
+                result = MLVersion.ReadFromELF(unityPlayerLinuxPath);
         }
 
         return result;

--- a/MelonLoader.Installer/MLVersion.cs
+++ b/MelonLoader.Installer/MLVersion.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Reflection.PortableExecutable;
 using ELF = ELFSharp.ELF;
+using MachO = ELFSharp.MachO;
 
 namespace MelonLoader.Installer;
 
@@ -118,24 +119,34 @@ public class MLVersion
         };
     }
 
+    public static Architecture ReadFromMachO(string filePath)
+    {
+        using var fs = File.OpenRead(filePath);
+        return MachO.MachOReader.TryLoadFat(fs, true, out var machOs) switch
+        {
+            MachO.MachOResult.OK => machOs[0].Machine switch
+            {
+                MachO.Machine.X86_64 => Architecture.MacOSX64,
+                MachO.Machine.Arm64 => Architecture.MacOSArm64,
+                _ => Architecture.Unknown
+            },
+            MachO.MachOResult.FatMachO =>
+                machOs.Any(x => x.Machine == MachO.Machine.X86_64)
+                    ? Architecture.MacOSX64
+                    : machOs.Any(x => x.Machine == MachO.Machine.Arm64)
+                        ? Architecture.MacOSArm64
+                        : Architecture.Unknown,
+            _ => Architecture.Unknown
+        };
+    }
+
     private static void ReadArchitecture(string filePath, out Architecture architecture)
     {
-        string proxyExt = Path.GetExtension(filePath);
-
-        bool isSO = (proxyExt == ".so");
-        if (isSO)
+        architecture = Path.GetExtension(filePath) switch
         {
-            architecture = ReadFromELF(filePath);
-            return;
-        }
-
-        bool isDylib = (proxyExt == ".dylib");
-        if (isDylib)
-        {
-            architecture = Architecture.MacOSX64;
-            return;
-        }
-
-        architecture = ReadFromPE(filePath);
+            ".so" => ReadFromELF(filePath),
+            ".dylib" => ReadFromMachO(filePath),
+            _ => ReadFromPE(filePath)
+        };
     }
 }

--- a/MelonLoader.Installer/MLVersion.cs
+++ b/MelonLoader.Installer/MLVersion.cs
@@ -1,6 +1,7 @@
 ﻿using Semver;
 using System.Diagnostics;
 using System.Reflection.PortableExecutable;
+using ELF = ELFSharp.ELF;
 
 namespace MelonLoader.Installer;
 
@@ -107,6 +108,16 @@ public class MLVersion
         return architecture;
     }
 
+    public static Architecture ReadFromELF(string filePath)
+    {
+        return ELF.ELFReader.CheckELFType(filePath) switch
+        {
+            ELF.Class.Bit32 => Architecture.LinuxX86,
+            ELF.Class.Bit64 => Architecture.LinuxX64,
+            _ => Architecture.Unknown,
+        };
+    }
+
     private static void ReadArchitecture(string filePath, out Architecture architecture)
     {
         string proxyExt = Path.GetExtension(filePath);
@@ -114,7 +125,7 @@ public class MLVersion
         bool isSO = (proxyExt == ".so");
         if (isSO)
         {
-            architecture = Architecture.LinuxX64;
+            architecture = ReadFromELF(filePath);
             return;
         }
 

--- a/MelonLoader.Installer/MelonLoader.Installer.csproj
+++ b/MelonLoader.Installer/MelonLoader.Installer.csproj
@@ -53,9 +53,9 @@
         <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
 
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageReference Include="ELFSharp" Version="2.17.3" />
         <PackageReference Include="Gameloop.Vdf" Version="0.6.2" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.10" />
         <PackageReference Include="Semver" Version="3.0.0" />
         <PackageReference Include="System.Drawing.Common" Version="9.0.10" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ MelonLoader.Installer is licensed under the Apache License, Version 2.0. See [LI
 
 ### Third-party libraries used:
 - [Avalonia](https://avaloniaui.net/) is licensed under the MIT License. See [LICENSE](https://github.com/AvaloniaUI/Avalonia/blob/master/licence.md) for the full License.
+- [ELFSharp](https://elfsharp.it/) is licensed under the MIT License. See [LICENSE](https://github.com/konrad-kruczynski/elfsharp/blob/master/LICENSE) for the full license.
 - [Gameloop.Vdf](https://github.com/shravan2x/Gameloop.Vdf) is licensed under the MIT License. See [LICENSE](https://github.com/shravan2x/Gameloop.Vdf/blob/master/LICENSE) for the full license.
 
 ### External tools downloaded:


### PR DESCRIPTION
Originally, the Linux installer finds the game executable only by file extensions, so if the game executable not including extensions (just like most programs on *nix do), the installer simply refuses to install to the game path.

Also, I've noticed that on macOS the installer just simply assumes the game to be x86_64 (probably caused by that MelonLoader doesn't have a "fully working" thing on osx-arm64), so I added the detection logic on both platforms.

Let me know if there are additional bugs to be addressed or other changes to be made.